### PR TITLE
add teeFormatter

### DIFF
--- a/examples/tee/tee.go
+++ b/examples/tee/tee.go
@@ -15,6 +15,7 @@ func main() {
 	if err != nil {
 		return
 	}
+	defer f.Close()
 	teeformatter := formatter.NewTee(formatter.NewCLI(false), f)
 
 	gologger.DefaultLogger.SetFormatter(teeformatter)

--- a/examples/tee/tee.go
+++ b/examples/tee/tee.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/gologger/formatter"
+)
+
+func main() {
+	fname := "gologger.json"
+
+	f, err := os.OpenFile(fname, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return
+	}
+	teeformatter := formatter.NewTee(formatter.NewCLI(false), f)
+
+	gologger.DefaultLogger.SetFormatter(teeformatter)
+
+	// Do iterations
+	gologger.Print().Msgf("\tgologger: sample test\t\n")
+	gologger.Info().Str("user", "pdteam").Msg("running simulation program")
+	for i := 0; i < 10; i++ {
+		gologger.Info().Str("count", strconv.Itoa(i)).Msg("running simulation step...")
+	}
+	gologger.Debug().Str("state", "running").Msg("planner running")
+	gologger.Warning().Str("state", "errored").Str("status", "404").Msg("could not run")
+	gologger.Fatal().Msg("bye bye")
+}

--- a/formatter/tee.go
+++ b/formatter/tee.go
@@ -1,0 +1,46 @@
+package formatter
+
+import (
+	"io"
+)
+
+// Tee formatter can be used to write the event to a writer while also use the existing formatter and output
+type Tee struct {
+	Wrapper Formatter
+	w       io.Writer
+
+	Formatter Formatter
+}
+
+// NewTee returns a new TeeWriter with default JSON messages
+func NewTee(wrapper Formatter, w io.Writer) (teeW *Tee) {
+	teeW = &Tee{
+		Wrapper:   wrapper,
+		Formatter: &JSON{},
+	}
+	teeW.w = w
+	return
+}
+
+// Format saves the event and forwards the event to the internal Wrapper
+func (tee *Tee) Format(event *LogEvent) (bts []byte, err error) {
+	if event == nil {
+		return
+	}
+	label, _ := event.Metadata["label"]
+
+	bts, err = tee.Format(event)
+	// the format delete the label key from Metadat - if we want colors we need to add it again
+	if label != "" {
+		event.Metadata["label"] = label
+	}
+	if err != nil {
+		return
+	}
+
+	if _, err = tee.w.Write(append(bts, []byte("\n")...)); err != nil {
+		return
+	}
+
+	return tee.Wrapper.Format(event)
+}

--- a/formatter/tee.go
+++ b/formatter/tee.go
@@ -39,7 +39,8 @@ func (tee *Tee) Format(event *LogEvent) (bts []byte, err error) {
 	}
 
 	if _, err = tee.w.Write(append(bts, []byte("\n")...)); err != nil {
-		return
+		// ignore write error to prevent complete loss of data
+		err = nil 
 	}
 
 	return tee.Wrapper.Format(event)

--- a/formatter/tee.go
+++ b/formatter/tee.go
@@ -27,7 +27,7 @@ func (tee *Tee) Format(event *LogEvent) (bts []byte, err error) {
 	if event == nil {
 		return
 	}
-	label, _ := event.Metadata["label"]
+	label := event.Metadata["label"]
 
 	bts, err = tee.Formatter.Format(event)
 	// the format delete the label key from Metadat - if we want colors we need to add it again
@@ -40,7 +40,7 @@ func (tee *Tee) Format(event *LogEvent) (bts []byte, err error) {
 
 	if _, err = tee.w.Write(append(bts, []byte("\n")...)); err != nil {
 		// ignore write error to prevent complete loss of data
-		err = nil 
+		err = nil
 	}
 
 	return tee.Wrapper.Format(event)

--- a/formatter/tee.go
+++ b/formatter/tee.go
@@ -29,7 +29,7 @@ func (tee *Tee) Format(event *LogEvent) (bts []byte, err error) {
 	}
 	label, _ := event.Metadata["label"]
 
-	bts, err = tee.Format(event)
+	bts, err = tee.Formatter.Format(event)
 	// the format delete the label key from Metadat - if we want colors we need to add it again
 	if label != "" {
 		event.Metadata["label"] = label


### PR DESCRIPTION
Hi, i'm recently using some pd tools and added some functionalities. 

This PR creates a TeeFormatter, which can be used to both send events to a io.Writer (e.g. file) as well as printing the same information on cli. 

Previously i tried to create a new Writer, but unfortunately the formatter is used first. 

To use best of both worlds (CLI colors AND json) i created the teeFormatter. 
