### PR TITLE
bump go 1.14  -> 1.19

### DIFF
--- a/formatter/tee.go
+++ b/formatter/tee.go
@@ -38,10 +38,8 @@ func (tee *Tee) Format(event *LogEvent) (bts []byte, err error) {
 		return
 	}
 
-	if _, err = tee.w.Write(append(bts, []byte("\n")...)); err != nil {
-		// ignore write error to prevent complete loss of data
-		err = nil
-	}
+	// ignore write error to prevent complete loss of data
+	_, _ = tee.w.Write(append(bts, []byte("\n")...))
 
 	return tee.Wrapper.Format(event)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,22 +1,25 @@
 module github.com/projectdiscovery/gologger
 
-go 1.14
+go 1.19
+
+require (
+	github.com/json-iterator/go v1.1.12
+	github.com/logrusorgru/aurora v2.0.3+incompatible
+	github.com/mholt/archiver v3.1.1+incompatible
+	gopkg.in/djherbis/times.v1 v1.3.0
+)
 
 require (
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/frankban/quicktest v1.11.3 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
-	github.com/json-iterator/go v1.1.12
 	github.com/kr/text v0.2.0 // indirect
-	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nwaples/rardecode v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/djherbis/times.v1 v1.3.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMx
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/djherbis/times.v1 v1.3.0 h1:uxMS4iMtH6Pwsxog094W0FYldiNnfY/xba00vq6C2+o=
 gopkg.in/djherbis/times.v1 v1.3.0/go.mod h1:AQlg6unIsrsCEdQYhTzERy542dz6SFdQFZFv6mUY0P8=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
### Proposed Changes

- bump go mod version to 1.19