### PR TITLE
fix Refactor levels order

### DIFF
--- a/levels/levels.go
+++ b/levels/levels.go
@@ -8,8 +8,8 @@ const (
 	LevelFatal Level = iota
 	LevelSilent
 	LevelError
-	LevelInfo
 	LevelWarning
+	LevelInfo
 	LevelDebug
 	LevelVerbose
 )


### PR DESCRIPTION
**Pull Request Title:** 
Fix issue with 'warn' log level not being displayed by changing default level to 'info'


**Changes Made:**
- Reorganized the order of log levels to maintain consistency。
