### PR TITLE
Dependency Update - CVE-2019-10743 Zip Slip Fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/json-iterator/go v1.1.12
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/mholt/archiver v3.1.1+incompatible
+	github.com/mholt/archiver@v3.3.2
 	gopkg.in/djherbis/times.v1 v1.3.0
 )
 


### PR DESCRIPTION
Hi team,

mholt/archiver@v3.3.1 dependency contains a zip slip vulnerability CVE-2019-10743
I was updated dependency. You can check the fix commit of the archiver project in [here](https://github.com/mholt/archiver/commit/8217ed3a206c0473b4ec1aff51375b398838073a)
