### PR TITLE
chore(deps): Address CVE-2024-0406

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,3 +23,7 @@ require (
 	github.com/ulikunitz/xz v0.5.11 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 )
+
+// TODO: This could be removed after https://github.com/mholt/archiver/pull/396 is merged.
+// This replace includes a resolution for https://github.com/advisories/GHSA-rhh4-rh7c-7r5v.
+replace github.com/mholt/archiver/v3 => github.com/anchore/archiver/v3 v3.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/anchore/archiver/v3 v3.5.2/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssnDhppzS1L4=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=
 github.com/andybalholm/brotli v1.0.6/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=


### PR DESCRIPTION
chore(deps): Address CVE-2024-0406
Fix tar path traversal through symlinks
https://github.com/advisories/GHSA-rhh4-rh7c-7r5v
https://github.com/mholt/archiver/pull/396