### PR TITLE
Feature/custom timestamp

### DIFF
--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -1,10 +1,9 @@
 package main
 
 import (
-	"strconv"
-
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/gologger/levels"
+	"strconv"
 )
 
 func main() {
@@ -23,6 +22,11 @@ func main() {
 	gologger.DefaultLogger.SetTimestamp(true, levels.LevelDebug)
 	gologger.Debug().Msg("with automatic timestamp")
 	gologger.Info().Msg("without automatic timestamp")
+
+	// custom time format
+	gologger.DefaultLogger.SetTimestamp(true, levels.LevelDebug, "2006-01-02 15:04:05")
+	gologger.Debug().Msg("with custom timestamp format")
+	gologger.Info().Msg("without custom timestamp format")
 
 	gologger.Fatal().Msg("bye bye")
 }

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"strconv"
+
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/gologger/levels"
-	"strconv"
 )
 
 func main() {

--- a/gologger.go
+++ b/gologger.go
@@ -31,13 +31,14 @@ func init() {
 	DefaultLogger.SetWriter(writer.NewCLI())
 }
 
-// Logger is a logger for logging structured data in a beautfiul and fast manner.
+// Logger is a logger for logging structured data in a beautiful and fast manner.
 type Logger struct {
 	writer            writer.Writer
 	maxLevel          levels.Level
 	formatter         formatter.Formatter
 	timestampMinLevel levels.Level
 	timestamp         bool
+	timestampFormat   string
 }
 
 // Log logs a message to a logger instance
@@ -76,10 +77,15 @@ func (l *Logger) SetWriter(writer writer.Writer) {
 	l.writer = writer
 }
 
-// SetTimestamp enables/disables automatic timestamp
-func (l *Logger) SetTimestamp(timestamp bool, minLevel levels.Level) {
+// SetTimestamp enables/disables automatic or custom timestamp
+func (l *Logger) SetTimestamp(timestamp bool, minLevel levels.Level, format ...string) {
 	l.timestamp = timestamp
 	l.timestampMinLevel = minLevel
+	if len(format) > 0 {
+		l.timestampFormat = format[0]
+	} else {
+		l.timestampFormat = time.RFC3339
+	}
 }
 
 // Event is a log event to be written with data
@@ -118,7 +124,7 @@ func (e *Event) Label(label string) *Event {
 
 // TimeStamp adds timestamp to the log event
 func (e *Event) TimeStamp() *Event {
-	e.metadata["timestamp"] = time.Now().Format(time.RFC3339)
+	e.metadata["timestamp"] = time.Now().Format(e.logger.timestampFormat)
 	return e
 }
 


### PR DESCRIPTION
When using logs, there is only automatic time.RFC3339, and the time format cannot be customized. I added an optional time format parameter to the SetTimestamp method, which allows logs to be output in a customized format.

example
```go
gologger.DefaultLogger.SetTimestamp(true, levels.LevelDebug, "2006-01-02 15:04:05")
gologger.Debug().Msg("with custom timestamp format")
gologger.Info().Msg("without custom timestamp format")
```

```
[DBG] [2025-04-22 11:19:20] with custom timestamp format
[INF] without custom timestamp format
```