### PR TITLE
restoring print to level silent

### DIFF
--- a/gologger.go
+++ b/gologger.go
@@ -259,7 +259,7 @@ func (l *Logger) Fatal() *Event {
 
 // Print prints a string on screen without any extra labels.
 func (l *Logger) Print() *Event {
-	event := newEventWithLevelAndLogger(levels.LevelInfo, l)
+	event := newEventWithLevelAndLogger(levels.LevelSilent, l)
 	return event
 }
 


### PR DESCRIPTION
Fixes #148. Restores v1.1.68 behaviour so `Print()` still emits when `MaxLevel=LevelSilent` (the documented "no-label payload" semantics).